### PR TITLE
Feat: 알림리스트에서 발신자를 이름이 아닌 PK로 찾는 기능 #360

### DIFF
--- a/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListAdapter.kt
+++ b/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListAdapter.kt
@@ -32,37 +32,10 @@ class NotificationListAdapter(val context: Context) :
                 checkboxNotificationList.layoutParams = params
 
                 textViewNotificationListSender.text = item.senderName
-
-
                 textViewNotificationListBody.text = item.content
                 imageViewNotificationListNew.visibility =
                     if (item.isRead) View.GONE else View.VISIBLE
-
-                // 날자 계산 필요. pattern: yyMMddHHmmssSSS
-                val date = SimpleDateFormat("yyMMddHHmmssSSS").parse(item.date)
-                val now = MainActivity.getMilliSec()
-                val year = now.substring(0, 2).toInt() - item.date.substring(0, 2).toInt()
-                val month = now.substring(2, 4).toInt() - item.date.substring(2, 4).toInt()
-                val day = now.substring(4, 6).toInt() - item.date.substring(4, 6).toInt()
-
-                var dateStr = ""
-                if (1 < year) {
-                    // 1년이 지났다면 연도로 표기
-                    if (month < 1) {
-                        dateStr = SimpleDateFormat("M월 d일", Locale.getDefault()).format(date)
-                    } else {
-                        dateStr = SimpleDateFormat("YYYY년", Locale.getDefault()).format(date)
-                    }
-                } else if (1 < day) {
-                    // 1년이 지나지 않았다면 00월 00일로 표기
-                    dateStr = SimpleDateFormat("M월 d일", Locale.getDefault()).format(date)
-                } else if (1 == day) {
-                    dateStr = "어제"
-                } else {
-                    // 하루 이내의 시간은 오전/후 hh:mm 로 표기
-                    dateStr = SimpleDateFormat("aa h:m", Locale.getDefault()).format(date)
-                }
-                textViewNotificationListDate.text = dateStr
+                textViewNotificationListDate.text = item.dateStr
 
                 if (isTrashCan) {
                     checkboxNotificationList.isChecked = item.isCheck
@@ -97,7 +70,7 @@ class NotificationListAdapter(val context: Context) :
 
                             subTitle.text = SimpleDateFormat(
                                 "yyyy년 M월 d일 aa h:m", Locale.getDefault()
-                            ).format(date)
+                            ).format(SimpleDateFormat("yyMMddHHmmssSSS").parse(item.date))
 
                             MaterialAlertDialogBuilder(context as MainActivity)
                                 .setCustomTitle(customTitle)

--- a/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListAdapter.kt
+++ b/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListAdapter.kt
@@ -31,7 +31,9 @@ class NotificationListAdapter(val context: Context) :
                 params.width = if (isTrashCan) ViewGroup.LayoutParams.WRAP_CONTENT else 0
                 checkboxNotificationList.layoutParams = params
 
-                textViewNotificationListSender.text = item.sender
+                textViewNotificationListSender.text = item.senderName
+
+
                 textViewNotificationListBody.text = item.content
                 imageViewNotificationListNew.visibility =
                     if (item.isRead) View.GONE else View.VISIBLE
@@ -70,7 +72,7 @@ class NotificationListAdapter(val context: Context) :
                 // 아이템 클릭 시 동작 구현
                 when (item.type) {
                     NotificationType.NOTIF_MESSAGE.str -> {
-                        textViewNotificationListSender.text = item.sender
+                        textViewNotificationListSender.text = item.senderName
                         textViewNotificationListBody.text = item.content
 
                         // 클릭 시 다이얼로그 생성
@@ -89,7 +91,7 @@ class NotificationListAdapter(val context: Context) :
                             )
                             val title =
                                 customTitle.findViewById<TextView>(R.id.textView_notification_dialog_customTitle)
-                            title.text = item.sender
+                            title.text = item.senderName
                             val subTitle =
                                 customTitle.findViewById<TextView>(R.id.textView_notification_dialog_subTitle)
 
@@ -108,7 +110,7 @@ class NotificationListAdapter(val context: Context) :
                     }
 
                     NotificationType.NOTIF_CHAT.str -> {
-                        textViewNotificationListSender.text = item.sender
+                        textViewNotificationListSender.text = item.senderName
                         textViewNotificationListBody.text = "채팅으로 이동합니다"
 
                         // 클릭 시 채팅으로 이동

--- a/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListAdapter.kt
+++ b/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListAdapter.kt
@@ -19,7 +19,7 @@ class NotificationListAdapter(val context: Context) :
     ListAdapter<NotificationListModel, NotificationListAdapter.NotificationListViewHolder>(diffUtil) {
     private var isTrashCan = false
     lateinit var actionCheckBoxParentState: () -> Unit
-    lateinit var actionGoToChat: (roomID: String) -> Unit
+    lateinit var actionGoToChat: (roomID: String, sender: String) -> Unit
     lateinit var actionUpdateIsRead: (notifID: String) -> Unit
 
     inner class NotificationListViewHolder(val bind: ItemNotificationListBinding) :
@@ -94,7 +94,7 @@ class NotificationListAdapter(val context: Context) :
                                 notifyDataSetChanged()
                             }
 
-                            actionGoToChat(item.content) //item.content == roomID
+                            actionGoToChat(item.content, item.sender) //item.content == roomID
                         }
                     }
                 }
@@ -145,7 +145,7 @@ class NotificationListAdapter(val context: Context) :
         actionCheckBoxParentState = action
     }
 
-    fun setGoToChat(action: (roomID: String) -> Unit) {
+    fun setGoToChat(action: (roomID: String, sender: String) -> Unit) {
         actionGoToChat = action
     }
 

--- a/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListFragment.kt
+++ b/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListFragment.kt
@@ -84,12 +84,20 @@ class NotificationListFragment : Fragment() {
             }
             notificationListAdapter.submitList(dataSet)
             notificationListAdapter.setCheckBoxParentState { setCheckBoxParentStete() }
-            notificationListAdapter.setGoToChat { roomID ->
-                Log.d("", "roomID = $roomID")
+            notificationListAdapter.setGoToChat { roomID, sender ->
+                Log.d(
+                    "notificationList to chattingRoom",
+                    "roomID = $roomID, sender = $sender, receiver = ${UserModel.roleId}"
+                )
+
+                val buyerId = if (UserModel.isSeller!!) sender else UserModel.roleId
+                val sellerId = if (!UserModel.isSeller!!) sender else UserModel.roleId
 
                 // 채팅방으로 이동
                 val bundle = Bundle()
                 bundle.putString("roomID", roomID)
+                bundle.putString("buyerId", buyerId)
+                bundle.putString("sellerId", sellerId)
                 findNavController().navigate(
                     R.id.action_notificationListFragment_to_chattingRoomFragment,
                     bundle

--- a/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListFragment.kt
+++ b/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListFragment.kt
@@ -19,6 +19,8 @@ import likelion.project.agijagi.MainActivity
 import likelion.project.agijagi.R
 import likelion.project.agijagi.databinding.FragmentNotificationListBinding
 import likelion.project.agijagi.model.UserModel
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class NotificationListFragment : Fragment() {
 
@@ -193,6 +195,36 @@ class NotificationListFragment : Fragment() {
                     for (data in datas) {
                         val content = data.getString("content")!!
                         val date = data.getString("date")!!
+
+                        // 날자 계산 필요. pattern: yyMMddHHmmssSSS
+                        val tempDate = SimpleDateFormat("yyMMddHHmmssSSS").parse(date)
+                        val now = MainActivity.getMilliSec()
+                        val year = now.substring(0, 2).toInt() - date.substring(0, 2).toInt()
+                        val month = now.substring(2, 4).toInt() - date.substring(2, 4).toInt()
+                        val day = now.substring(4, 6).toInt() - date.substring(4, 6).toInt()
+
+                        var dateStr = ""
+                        if (1 < year) {
+                            // 1년이 지났다면 연도로 표기
+                            if (month < 1) {
+                                dateStr =
+                                    SimpleDateFormat("M월 d일", Locale.getDefault()).format(tempDate)
+                            } else {
+                                dateStr =
+                                    SimpleDateFormat("YYYY년", Locale.getDefault()).format(tempDate)
+                            }
+                        } else if (1 < day) {
+                            // 1년이 지나지 않았다면 00월 00일로 표기
+                            dateStr =
+                                SimpleDateFormat("M월 d일", Locale.getDefault()).format(tempDate)
+                        } else if (1 == day) {
+                            dateStr = "어제"
+                        } else {
+                            // 하루 이내의 시간은 오전/후 hh:mm 로 표기
+                            dateStr =
+                                SimpleDateFormat("aa h:m", Locale.getDefault()).format(tempDate)
+                        }
+
                         val is_chat = data.getBoolean("is_chat")!!
                         val is_read = data.getBoolean("is_read")!!
 
@@ -235,6 +267,7 @@ class NotificationListFragment : Fragment() {
                             senderName,
                             content,
                             date,
+                            dateStr,
                             type.str,
                             is_read
                         )

--- a/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListModel.kt
+++ b/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListModel.kt
@@ -3,8 +3,9 @@ package likelion.project.agijagi.notification
 data class NotificationListModel(
     var id: String, // 알림 pk
     var sender: String, //보낸 이
+    var senderName: String, // seller BussinessName, buyer nickName, system agijagi
     var content: String, // 본문
-    var date: String, // 보낸 시간 (yyMMddhhmmssSSS)
+    var date: String, // 보낸 시간 (yyMMddHHmmssSSS)
     var type: String = "message", // NotificationType.str
     var isRead: Boolean = false, // 확인 여부 (false: new!)
     var isCheck: Boolean = false // 삭제 시 사용

--- a/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListModel.kt
+++ b/agijagi/app/src/main/java/likelion/project/agijagi/notification/NotificationListModel.kt
@@ -6,6 +6,7 @@ data class NotificationListModel(
     var senderName: String, // seller BussinessName, buyer nickName, system agijagi
     var content: String, // 본문
     var date: String, // 보낸 시간 (yyMMddHHmmssSSS)
+    var dateStr: String, // 화면에 표시할 값
     var type: String = "message", // NotificationType.str
     var isRead: Boolean = false, // 확인 여부 (false: new!)
     var isCheck: Boolean = false // 삭제 시 사용


### PR DESCRIPTION
- 알림 메시지의 sender를 pk로 찾아 표시
- 채팅룸 이동 시 번들에 buyerId, sellerId 항목 추가
- refactor: 날자 표기 조건식을 Adapter에서 Fragment 로 이동 (코드정리)

현재 aaa@aa.aa 계정에서 확인 가능